### PR TITLE
use multiprocessing for genoud optimizer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: DiceOptim
-Version: 1.5
+Version: 1.5.1
 Title: Kriging-Based Optimization for Computer Experiments
 Date: 2015-03-10
 Author: D. Ginsbourger, V. Picheny, O. Roustant, with contributions by

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Author: D. Ginsbourger, V. Picheny, O. Roustant, with contributions by
 Maintainer: D. Ginsbourger <david.ginsbourger@stat.unibe.ch>
 Description: Expected Improvement. EGO algorithm. Multipoint EI and parallelized versions of EGO. Criteria and algorithms for Noisy Kriging-based Optimization , including AEI, AKG, EQI, and EI with plugin.
 Depends: DiceKriging (>= 1.2), rgenoud, MASS, lhs, mnormt
+Imports: doParallel
 License: GPL-2 | GPL-3
 URL: http://dice.emse.fr/
 Packaged: 2015-03-10 16:49:26 UTC; ginsbourger

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,8 @@ Author: D. Ginsbourger, V. Picheny, O. Roustant, with contributions by
         C. Chevalier,  S. Marmin, and T. Wagner
 Maintainer: D. Ginsbourger <david.ginsbourger@stat.unibe.ch>
 Description: Expected Improvement. EGO algorithm. Multipoint EI and parallelized versions of EGO. Criteria and algorithms for Noisy Kriging-based Optimization , including AEI, AKG, EQI, and EI with plugin.
-Depends: DiceKriging (>= 1.2), rgenoud, MASS, lhs, mnormt
-Imports: doParallel
+Depends: DiceKriging (>= 1.2), MASS, lhs, mnormt
+Imports: doParallel, rgenoud
 License: GPL-2 | GPL-3
 URL: http://dice.emse.fr/
 Packaged: 2015-03-10 16:49:26 UTC; ginsbourger

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,6 @@
 import("DiceKriging","lhs","mnormt",
 	"rgenoud", "MASS")
+importFrom("doParallel", "registerDoParallel")
 
 export( EI,EI.grad,max_EI,EGO.nsteps, 
 qEI, qEI.grad, max_qEI, sampleFromEI,qEGO.nsteps,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,6 @@
-import("DiceKriging","lhs","mnormt",
-	"rgenoud", "MASS")
+import("DiceKriging","lhs","mnormt", "MASS")
 importFrom("doParallel", "registerDoParallel")
+importFrom("rgenoud", "genoud")
 
 export( EI,EI.grad,max_EI,EGO.nsteps, 
 qEI, qEI.grad, max_qEI, sampleFromEI,qEGO.nsteps,

--- a/R/AKG.grad.R
+++ b/R/AKG.grad.R
@@ -41,6 +41,7 @@ AKG.grad <- function(x, model, new.noise.var=0, type = "UK", envir=NULL){
       
       ######### Compute a and b #########
       a <- c(mk.X, mk.x)
+browser()
       b <- cn / sqrt(tau2.new + sk.x^2)
       sQ <- b[model@n+1]
     }
@@ -88,9 +89,9 @@ AKG.grad <- function(x, model, new.noise.var=0, type = "UK", envir=NULL){
     }
 #     print(t(dc.x) - t(t(V.X)%*%W))
     cn.grad <- t(dc.x) - t(t(V.X)%*%W) + mu.x.grad
-    
     b.grad[,1:model@n] <- cn.grad/sqrt(tau2.new+sk.x^2) - sk2.x.grad%*%cn[1:model@n]*as.numeric(1/2/(tau2.new+sk.x^2)^(3/2))
-    b.grad[,model@n+1] <- as.numeric(sk.x^2*(2*tau2.new+sk.x^2)/(tau2.new+sk.x^2)^2)*sk2.x.grad/as.numeric(2*sQ)
+    b.grad[,model@n+1] <- as.numeric(sk.x^2*(2*tau2.new+sk.x^2)/(tau2.new+sk.x^2)^2)*
+        sk2.x.grad/as.numeric(2*sQ)
     
     ######### Careful: the AKG is written for MAXIMIZATION #########
     ######### Minus signs have been added where necessary ##########

--- a/R/CL.nsteps.R
+++ b/R/CL.nsteps.R
@@ -1,4 +1,6 @@
-CL.nsteps <- function (model, fun, npoints, nsteps, lower, upper, parinit = NULL, kmcontrol = NULL, control=NULL) {
+CL.nsteps <- function (model, fun, npoints, nsteps, lower, upper, parinit = NULL,
+                       kmcontrol = NULL, control=NULL,
+                       multistart=1) {
     
     n <- nrow(model@X)
 
@@ -18,7 +20,9 @@ CL.nsteps <- function (model, fun, npoints, nsteps, lower, upper, parinit = NULL
 	  	model <- km(formula=model@trend.formula, design=model@X, response=model@y, 
 	  		    covtype=model@covariance@name, lower=model@lower, upper=model@upper, 
                             nugget=NULL, penalty=kmcontrol$penalty, optim.method=kmcontrol$optim.method, 
-		    	    parinit=kmcontrol$parinit, control=kmcontrol$control, gr=model@gr)
+		    	    parinit=kmcontrol$parinit, control=kmcontrol$control,
+                            gr=model@gr,
+                            multistart=multistart)
 	  	            
 	}
 

--- a/R/EGO.nsteps.R
+++ b/R/EGO.nsteps.R
@@ -25,7 +25,9 @@ EGO.nsteps <-function(model, fun, nsteps, lower, upper, parinit=NULL, control=NU
 			model <- km(formula=model@trend.formula, design=model@X, response=model@y, 
 		   		 covtype=model@covariance@name, lower=model@lower, upper=model@upper, 
                  nugget=NULL, penalty=kmcontrol$penalty, optim.method=kmcontrol$optim.method, 
-		    	parinit=kmcontrol$parinit, control=kmcontrol$control, gr=model@gr, iso=is(model@covariance,"covIso"))
+		    	parinit=kmcontrol$parinit, control=kmcontrol$control,
+                                    gr=model@gr, iso=is(model@covariance,"covIso"),
+                                    multistart=multistart)
 		} else {
 			coef.cov <- covparam2vect(model@covariance)
 			model <- km(formula=model@trend.formula, design=model@X, response=model@y, 

--- a/R/EGO.nsteps.R
+++ b/R/EGO.nsteps.R
@@ -1,4 +1,6 @@
-EGO.nsteps <-function(model, fun, nsteps, lower, upper, parinit=NULL, control=NULL, kmcontrol=NULL) {
+EGO.nsteps <-function(model, fun, nsteps, lower, upper, parinit=NULL, control=NULL,
+                      kmcontrol=NULL,
+                      multistart=1) {
 
 	n <- nrow(model@X)
 	
@@ -27,7 +29,11 @@ EGO.nsteps <-function(model, fun, nsteps, lower, upper, parinit=NULL, control=NU
 		} else {
 			coef.cov <- covparam2vect(model@covariance)
 			model <- km(formula=model@trend.formula, design=model@X, response=model@y, 
-		   		 covtype=model@covariance@name, coef.trend=model@trend.coef, coef.cov=coef.cov, coef.var=model@covariance@sd2, nugget=NULL, iso=is(model@covariance,"covIso"))
+		   		 covtype=model@covariance@name,
+                                    coef.trend=model@trend.coef, coef.cov=coef.cov,
+                                    coef.var=model@covariance@sd2, nugget=NULL,
+                                    iso=is(model@covariance,"covIso"),
+                                    multistart=multistart)
 		}
 	}
 	

--- a/R/max_AEI.R
+++ b/R/max_AEI.R
@@ -1,5 +1,6 @@
 #source("max_AEI.R")
-max_AEI <-function(model, new.noise.var=0, y.min=NULL, type = "UK", lower, upper, parinit=NULL, control=NULL) {
+max_AEI <-function(model, new.noise.var=0, y.min=NULL, type = "UK", lower, upper,
+                   parinit=NULL, control=NULL, cluster=FALSE) {
 
   # Compute y.min if missing
   if (is.null(y.min))
@@ -33,7 +34,7 @@ max_AEI <-function(model, new.noise.var=0, y.min=NULL, type = "UK", lower, upper
 	            share.type=0, instance.number=0, output.path="stdout", output.append=FALSE, project.path=NULL,
 	            P1=50, P2=50, P3=50, P4=50, P5=50, P6=50, P7=50, P8=50, P9=0, P9mix=NULL, 
 	            BFGSburnin=control$BFGSburnin, BFGSfn=NULL, BFGShelp=NULL, control=list("maxit"=control$BFGSmaxit), 
-	            cluster=FALSE, balance=FALSE, debug=FALSE, 
+	            cluster=cluster, balance=FALSE, debug=FALSE, 
               model=model, new.noise.var=new.noise.var, y.min=y.min, type=type, envir=AEI.envir 
 		)
                             

--- a/R/max_AKG.R
+++ b/R/max_AKG.R
@@ -19,7 +19,6 @@ max_AKG <-function(model, new.noise.var=0, type = "UK", lower, upper, parinit=NU
 	if (is.null(parinit))  parinit <- lower + runif(d) * (upper - lower)
      
 	domaine <- cbind(lower, upper)
-
 	o <- genoud(AKG, nvars=d, max=TRUE,
 	            pop.size=control$pop.size, max.generations=control$max.generations, wait.generations=control$wait.generations,
 	            hard.generation.limit=TRUE, starting.values=parinit, MemoryMatrix=TRUE, 

--- a/R/max_AKG.R
+++ b/R/max_AKG.R
@@ -1,5 +1,7 @@
 #source("max_AKG.R")
-max_AKG <-function(model, new.noise.var=0, type = "UK", lower, upper, parinit=NULL, control=NULL) {
+max_AKG <-function(model, new.noise.var=0, type = "UK", lower, upper, parinit=NULL,
+                   control=NULL,
+                   cluster=FALSE) {
 
 	AKG.envir <- new.env()	
 	environment(AKG) <- environment(AKG.grad) <- AKG.envir 
@@ -28,7 +30,7 @@ max_AKG <-function(model, new.noise.var=0, type = "UK", lower, upper, parinit=NU
               share.type=0, instance.number=0, output.path="stdout", output.append=FALSE, project.path=NULL,
 	            P1=50, P2=50, P3=50, P4=50, P5=50, P6=50, P7=50, P8=50, P9=0,	P9mix=NULL, 
               BFGSburnin=control$BFGSburnin, BFGSfn=NULL, BFGShelp=NULL, control=list("maxit"=control$BFGSmaxit),
-	            cluster=FALSE, balance=FALSE, debug=TRUE, 
+	            cluster=cluster, balance=FALSE, debug=TRUE, 
 	            model=model, new.noise.var=new.noise.var, type=type, envir=AKG.envir
 		)
                             

--- a/R/max_EI.R
+++ b/R/max_EI.R
@@ -1,5 +1,7 @@
 #source("max_EI.R")
-max_EI <-function(model, plugin=NULL, type = "UK", lower, upper, parinit=NULL, minimization = TRUE, control=NULL) {
+max_EI <-function(model, plugin=NULL, type = "UK", lower, upper, parinit=NULL,
+                  minimization = TRUE, control=NULL,
+                  cluster=FALSE) {
 
   if (is.null(plugin)){ plugin <- min(model@y) }
   
@@ -31,7 +33,7 @@ max_EI <-function(model, plugin=NULL, type = "UK", lower, upper, parinit=NULL, m
 	            share.type=0, instance.number=0, output.path="stdout", output.append=FALSE, project.path=NULL,
 	            P1=50, P2=50, P3=50, P4=50, P5=50, P6=50, P7=50, P8=50, P9=0, P9mix=NULL, 
 	            BFGSburnin=control$BFGSburnin, BFGSfn=NULL, BFGShelp=NULL, control=list("maxit"=control$BFGSmaxit), 
-	            cluster=FALSE, balance=FALSE, debug=FALSE,
+	            cluster=cluster, balance=FALSE, debug=FALSE,
 	            model=model, plugin=plugin, type=type,minimization = minimization, envir=EI.envir
 	)
   

--- a/R/max_EQI.R
+++ b/R/max_EQI.R
@@ -1,5 +1,6 @@
 #source("max_EQI.R")
-max_EQI <-function(model, new.noise.var=0, beta=0.9, q.min=NULL, type = "UK", lower, upper, parinit=NULL, control=NULL) {
+max_EQI <-function(model, new.noise.var=0, beta=0.9, q.min=NULL, type = "UK", lower,
+                   upper, parinit=NULL, control=NULL, cluster=FALSE) {
 
   ######### Compute q.min if missing #########
   if (is.null(q.min))
@@ -33,7 +34,7 @@ max_EQI <-function(model, new.noise.var=0, beta=0.9, q.min=NULL, type = "UK", lo
 	            share.type=0, instance.number=0, output.path="stdout", output.append=FALSE, project.path=NULL,
 	            P1=50, P2=50, P3=50, P4=50, P5=50, P6=50, P7=50, P8=50, P9=0, P9mix=NULL, 
 	            BFGSburnin=control$BFGSburnin, BFGSfn=NULL, BFGShelp=NULL, control=list("maxit"=control$BFGSmaxit), 
-	            cluster=FALSE, balance=FALSE, debug=FALSE, 
+	            cluster=cluster, balance=FALSE, debug=FALSE, 
               model=model, new.noise.var=new.noise.var, beta=beta, q.min=q.min, type=type, envir=EQI.envir
 		)
                             

--- a/R/max_qEI.R
+++ b/R/max_qEI.R
@@ -1,4 +1,6 @@
-max_qEI <- function(model, npoints, lower, upper, crit="exact", minimization = TRUE, optimcontrol=NULL) {  
+max_qEI <- function(model, npoints, lower, upper, crit="exact", minimization = TRUE,
+                    optimcontrol=NULL,
+                    cluster=FALSE) {  
   if (is.null(optimcontrol$method)) optimcontrol$method <- "BFGS"
   optim.method <- optimcontrol$method
   d <- model@d 
@@ -74,7 +76,7 @@ max_qEI <- function(model, npoints, lower, upper, crit="exact", minimization = T
                     output.path = "stdout", output.append = FALSE, project.path = NULL, 
                     P1 = 50, P2 = 50, P3 = 50, P4 = 50, P5 = 50, P6 = 50, 
                     P7 = 50, P8 = 50, P9 = 0, P9mix = NULL, BFGSburnin = optimcontrol$BFGSburnin, 
-                    BFGSfn = NULL, BFGShelp = NULL, cluster = FALSE, balance = FALSE, 
+                    BFGSfn = NULL, BFGShelp = NULL, cluster = cluster, balance = FALSE, 
                     debug = FALSE, model = model,fastCompute = optimcontrol$fastCompute,minimization=minimization,envir=EI.envir)
         
         o$par <- matrix(o$par,ncol=d)

--- a/R/min_quantile.R
+++ b/R/min_quantile.R
@@ -1,5 +1,7 @@
 #source("min_quantile.R")
-min_quantile <-function(model, beta=0.1, type = "UK", lower, upper, parinit=NULL, control=NULL) {
+min_quantile <-function(model, beta=0.1, type = "UK", lower, upper, parinit=NULL,
+                        control=NULL,
+                        cluster=FALSE) {
 
 	quantile.envir <- new.env()
 	environment(kriging.quantile) <- environment(kriging.quantile.grad) <- quantile.envir 
@@ -28,7 +30,7 @@ min_quantile <-function(model, beta=0.1, type = "UK", lower, upper, parinit=NULL
 	            share.type=0, instance.number=0, output.path="stdout", output.append=FALSE, project.path=NULL,
 	            P1=50, P2=50, P3=50, P4=50, P5=50, P6=50, P7=50, P8=50, P9=0, P9mix=NULL, 
 	            BFGSburnin=control$BFGSburnin, BFGSfn=NULL, BFGShelp=NULL, control=list("maxit"=control$BFGSmaxit), 
-	            cluster=FALSE, balance=FALSE, debug=FALSE, 
+	            cluster=cluster, balance=FALSE, debug=FALSE, 
               model=model, beta=beta, type=type, envir=quantile.envir 
 		)
                             

--- a/R/noisy.optimizer.R
+++ b/R/noisy.optimizer.R
@@ -29,12 +29,20 @@ noisy.optimizer <- function(optim.crit, optim.param=NULL, model, n.ite, noise.va
   cat("----------------- \n")
   optim.result <- list()
   ## Prepare the multistart for dicekriging
-  if(is.null(cluster)) {
+  if(length(cluster) < 2) {
      multistart <- 1
+     cluster <- FALSE
+                           # just to ensure if fits to genoud()
   }
   else {
-     doParallel::registerDoParallel(cluster)
-     multistart <- length(cluster)
+     if(inherits(cluster, "cluster")) {
+        doParallel::registerDoParallel(cluster)
+        multistart <- length(cluster)
+     }
+     else {
+        stop("'cluster' object must either be 'FALSE' or of class 'cluster'.\n",
+             "Currently it is ", class(cluster))
+     }
   }
   #---------------------------------------------------------------------------------------------------------
   # Initialization for the unknown noise variance case

--- a/R/noisy.optimizer.R
+++ b/R/noisy.optimizer.R
@@ -33,7 +33,7 @@ noisy.optimizer <- function(optim.crit, optim.param=NULL, model, n.ite, noise.va
      multistart <- 1
   }
   else {
-     doParallel::registerDoParallel(cl)
+     doParallel::registerDoParallel(cluster)
      multistart <- length(cluster)
   }
   #---------------------------------------------------------------------------------------------------------
@@ -289,7 +289,7 @@ noisy.optimizer <- function(optim.crit, optim.param=NULL, model, n.ite, noise.va
     upmod <- update_km_noisyEGO(model=model, x.new=x.new, y.new=y.new, noise.var=noise.var, type=type,
                                 add.obs=add.obs, index.in.DOE=i.best, CovReEstimate=CovReEstimate, NoiseReEstimate=NoiseReEstimate, 
                                 estim.model=estim.model, nugget.LB=nugget.LB,
-                                multistart=multistart)
+                                cluster=cluster)
     model <- upmod$model
     if (NoiseReEstimate)
     { estim.model <- upmod$estim.model

--- a/R/noisy.optimizer.R
+++ b/R/noisy.optimizer.R
@@ -2,7 +2,7 @@
 noisy.optimizer <- function(optim.crit, optim.param=NULL, model, n.ite, noise.var=NULL, funnoise, lower, upper, 
                       parinit=NULL, control=NULL,CovReEstimate=TRUE,NoiseReEstimate=FALSE, 
                             nugget.LB=1e-5, estim.model=NULL, type="UK",
-                            cluster=NULL)
+                            cluster=FALSE)
 {
   ############################################################################################################
   # A switch is made at every iteration to choose the corresponding infill criterion, then the model is updated 

--- a/R/noisy.optimizer.R
+++ b/R/noisy.optimizer.R
@@ -1,7 +1,8 @@
 #source("noisy.EGO.R")
 noisy.optimizer <- function(optim.crit, optim.param=NULL, model, n.ite, noise.var=NULL, funnoise, lower, upper, 
                       parinit=NULL, control=NULL,CovReEstimate=TRUE,NoiseReEstimate=FALSE, 
-                      nugget.LB=1e-5, estim.model=NULL, type="UK")
+                            nugget.LB=1e-5, estim.model=NULL, type="UK",
+                            cluster=NULL)
 {
   ############################################################################################################
   # A switch is made at every iteration to choose the corresponding infill criterion, then the model is updated 
@@ -19,9 +20,9 @@ noisy.optimizer <- function(optim.crit, optim.param=NULL, model, n.ite, noise.va
   #    - "noise.var": initial guess for the unknown variance (used in optimization)
   #    - "obs.n.rep": number of repetitions per observation point. Required if "model" has heterogeneous variances
   #    - "estim.model": model with homogeneous nugget effect (no noise.var). Required only for restarting algorithms
+  #    - "cluster":     run the rgenoud optimizer on this cluster
   #
   ############################################################################################################
-  
   cat("Starting noisy optimization with the following criterion and parameters \n")
   cat(optim.crit, "\n")
   if(!is.null(optim.param))  print(optim.param,quote=FALSE)
@@ -244,7 +245,9 @@ noisy.optimizer <- function(optim.crit, optim.param=NULL, model, n.ite, noise.va
     else if (optim.crit =="AKG")
     {
       # Choose new observation based on AKG
-      oEGO <- max_AKG(model=model, new.noise.var=noise.var, type=type, lower=lower, upper=upper, parinit=parinit, control=control)
+       oEGO <- max_AKG(model=model, new.noise.var=noise.var, type=type, lower=lower,
+                      upper=upper, parinit=parinit, control=control,
+                      cluster=cluster)
       x.new <- oEGO$par
       AKG <- oEGO$val
 

--- a/R/update_km_noisyEGO.R
+++ b/R/update_km_noisyEGO.R
@@ -2,19 +2,26 @@
 update_km_noisyEGO <- function(model, x.new, y.new, noise.var=0, type="UK", add.obs=TRUE, index.in.DOE=NULL, 
                                CovReEstimate=TRUE, NoiseReEstimate=FALSE,
                                estim.model=NULL, nugget.LB=1e-5,
-                               cluster=NULL)
+                               cluster=FALSE)
 {
   i.new <- index.in.DOE
   cov.reestim <- CovReEstimate
   trend.reestim <- FALSE
   if (type=="UK") {trend.reestim <- TRUE}
   ## Prepare the multistart for dicekriging
-  if(is.null(cluster)) {
+  if(length(cluster) < 2) {
      multistart <- 1
+     cluster <- FALSE
   }
   else {
-     doParallel::registerDoParallel(cluster)
-     multistart <- length(cluster)
+     if(inherits(cluster, "cluster")) {
+        doParallel::registerDoParallel(cluster)
+        multistart <- length(cluster)
+     }
+     else {
+        stop("'cluster' object must either be 'FALSE' or of class 'cluster'.\n",
+             "Currently it is ", class(cluster))
+     }
   }
   #-------------------------------------------------------------------------------------------------------
   #-- Case 1: unknown noise variance ---------------------------------------------------------------------

--- a/R/update_km_noisyEGO.R
+++ b/R/update_km_noisyEGO.R
@@ -13,7 +13,7 @@ update_km_noisyEGO <- function(model, x.new, y.new, noise.var=0, type="UK", add.
      multistart <- 1
   }
   else {
-     doParallel::registerDoParallel(cl)
+     doParallel::registerDoParallel(cluster)
      multistart <- length(cluster)
   }
   #-------------------------------------------------------------------------------------------------------

--- a/R/update_km_noisyEGO.R
+++ b/R/update_km_noisyEGO.R
@@ -1,12 +1,21 @@
 #source("update_km_noisyEGO.R")
 update_km_noisyEGO <- function(model, x.new, y.new, noise.var=0, type="UK", add.obs=TRUE, index.in.DOE=NULL, 
-                               CovReEstimate=TRUE, NoiseReEstimate=FALSE, estim.model=NULL, nugget.LB=1e-5)
+                               CovReEstimate=TRUE, NoiseReEstimate=FALSE,
+                               estim.model=NULL, nugget.LB=1e-5,
+                               cluster=NULL)
 {
   i.new <- index.in.DOE
   cov.reestim <- CovReEstimate
   trend.reestim <- FALSE
   if (type=="UK") {trend.reestim <- TRUE}
-  
+  ## Prepare the multistart for dicekriging
+  if(is.null(cluster)) {
+     multistart <- 1
+  }
+  else {
+     doParallel::registerDoParallel(cl)
+     multistart <- length(cluster)
+  }
   #-------------------------------------------------------------------------------------------------------
   #-- Case 1: unknown noise variance ---------------------------------------------------------------------
   #-------------------------------------------------------------------------------------------------------
@@ -103,11 +112,15 @@ update_km_noisyEGO <- function(model, x.new, y.new, noise.var=0, type="UK", add.
     {
       if (type=="UK")
       { newmodel <- try(km(formula=model@trend.formula, design=model@X, response=model@y, covtype=model@covariance@name, noise.var=model@noise.var,
-                         parinit=covparam2vect(model@covariance),lower=model@lower, upper=model@upper,control=model@control))
+                         parinit=covparam2vect(model@covariance),lower=model@lower,
+                           upper=model@upper,control=model@control,
+                           multistart=multistart))
       } else
       { newmodel <- try(km(formula=model@trend.formula, design=model@X, response=model@y, covtype=model@covariance@name, noise.var=model@noise.var,
                            coef.trend=model@trend.coef,
-                           parinit=covparam2vect(model@covariance),lower=model@lower, upper=model@upper,control=model@control))
+                           parinit=covparam2vect(model@covariance),lower=model@lower,
+                           upper=model@upper,control=model@control,
+                           multistart=multistart))
       }
       
       # If km crashes: try to build it again with old hyperparameters
@@ -116,7 +129,9 @@ update_km_noisyEGO <- function(model, x.new, y.new, noise.var=0, type="UK", add.
         newmodel <- km(formula=model@trend.formula, design=model@X, response=model@y, covtype=model@covariance@name, 
                        noise.var=model@noise.var, control=model@control,
                        coef.trend=model@trend.coef, coef.cov=covparam2vect(model@covariance), 
-                       coef.var=model@covariance@sd2, lower=model@lower, upper=model@upper)
+                       coef.var=model@covariance@sd2, lower=model@lower,
+                       upper=model@upper,
+                       multistart=multistart)
       }
     } else # If no hyperparameter reestimation
     {  newmodel <- computeAuxVariables(model)

--- a/man/EGO.nsteps.Rd
+++ b/man/EGO.nsteps.Rd
@@ -12,7 +12,8 @@ then a new point is obtained by maximizing the Expected Improvement criterion (\
 
 \usage{
 EGO.nsteps(model, fun, nsteps, lower, upper, parinit=NULL, 
-control=NULL, kmcontrol=NULL)
+control=NULL, kmcontrol=NULL,
+multistart=1)
 }
 
 
@@ -45,15 +46,16 @@ control=NULL, kmcontrol=NULL)
 		of the function \code{\link[rgenoud]{genoud}}. }
 
   \item{kmcontrol}{ an optional list representing the control variables for the re-estimation of the kriging model. 
-		    The items are the same as in \code{\link[DiceKriging]{km}} : 
-
-		\code{penalty}, \code{optim.method}, \code{parinit}, \code{control}. 
-
-		The default values are those contained in \code{model}, typically corresponding to the variables 
-		used in \code{\link[DiceKriging]{km}} to estimate a kriging model from the initial design points.}
+    The items are the same as in \code{\link[DiceKriging]{km}} : 
+    \code{penalty}, \code{optim.method}, \code{parinit}, \code{control}. 
+    The default values are those contained in \code{model}, typically corresponding to the variables 
+    used in \code{\link[DiceKriging]{km}} to estimate a
+    kriging model from the initial design points.}
+  \item{multistart}{an integer, number of parallel kriging optimizations
+    (see \code{\link{km}}.)  Note, one has to register the corresponding
+    cluster by \code{\link[doParallel]{registerDoParallel}} (see package
+    \dQuote{foreach}).}
 }
-
-
 
 \value{ A list with components:
 

--- a/man/max_AEI.Rd
+++ b/man/max_AEI.Rd
@@ -9,7 +9,8 @@ Maximization, based on the package rgenoud of the Augmented Expected Improvement
 
 \usage{
 max_AEI(model, new.noise.var=0, y.min=NULL, type = "UK", 
-lower, upper, parinit=NULL, control=NULL)
+        lower, upper, parinit=NULL, control=NULL,
+        cluster=FALSE)
 }
 
 \arguments{
@@ -31,8 +32,13 @@ lower, upper, parinit=NULL, control=NULL)
    \item{control}{  optional list of control parameters for optimization. 
 One can control  \code{"pop.size"}  (default : [N=3*2^dim for dim<6 and N=32*dim otherwise]),  \code{"max.generations"} (12),  
 \code{"wait.generations"} (2) and  \code{"BFGSburnin"} (2) of function  \code{"genoud"} (see \code{\link[rgenoud]{genoud}}). 
-Numbers into brackets are the default values }  
-
+Numbers into brackets are the default values }
+   \item{cluster}{to invoke \code{\link{km}} and \code{\link{genoud}} in parallel, 
+     an object of the 'cluster' class returned
+     by one of the \code{\link{makeCluster}} commands in the
+     \sQuote{parallel} 
+     package, or a vector of machine names.  See
+     \code{\link{genoud}} for further details.}
 }
 
 \value{A list with components:

--- a/man/max_AKG.Rd
+++ b/man/max_AKG.Rd
@@ -8,7 +8,10 @@
 Maximization, based on the package rgenoud of the Expected Quantile Improvement (AKG) criterion.}
 
 \usage{
-max_AKG(model, new.noise.var=0, type = "UK", lower, upper, parinit=NULL, control=NULL)
+max_AKG(model, new.noise.var=0, type = "UK", lower, upper, parinit=NULL,
+        control=NULL,
+        cluster=FALSE
+)
 }
 
 \arguments{
@@ -28,7 +31,13 @@ max_AKG(model, new.noise.var=0, type = "UK", lower, upper, parinit=NULL, control
 One can control  \code{"pop.size"}  (default : [N=3*2^dim for dim<6 and N=32*dim otherwise]),  \code{"max.generations"} (12),  
 \code{"wait.generations"} (2) and  \code{"BFGSburnin"} (2) of function  \code{"genoud"} (see \code{\link[rgenoud]{genoud}}). 
 Numbers into brackets are the default values }  
-
+  \item{cluster}{to invoke \code{\link{genoud}} in parallel, 
+  an object of the 'cluster' class returned
+  by one of the \code{\link{makeCluster}} commands in the
+  \sQuote{parallel} 
+  package or a vector of machine names.  See
+  \code{\link{genoud}} for further details.
+}
 }
 
 \value{A list with components:

--- a/man/max_EI.Rd
+++ b/man/max_EI.Rd
@@ -18,7 +18,7 @@ The current minimum of the observations can be replaced by an arbitrary value (p
 
 \usage{
 max_EI(model, plugin=NULL, type="UK", lower, upper, parinit=NULL, 
-minimization = TRUE, control = NULL) }
+minimization = TRUE, control = NULL, cluster=FALSE) }
 
 \arguments{
 
@@ -40,7 +40,12 @@ minimization = TRUE, control = NULL) }
 One can control  \code{"pop.size"}  (default : [N=3*2^dim for dim<6 and N=32*dim otherwise]),  \code{"max.generations"} (12),  
 \code{"wait.generations"} (2) and  \code{"BFGSburnin"} (2) of function  \code{"genoud"} (see \code{\link[rgenoud]{genoud}}). 
 Numbers into brackets are the default values } 
-
+   \item{cluster}{to invoke \code{\link{km}} and \code{\link{genoud}} in parallel, 
+   an object of the 'cluster' class returned
+   by one of the \code{\link{makeCluster}} commands in the
+   \sQuote{parallel} 
+   package, or a vector of machine names.  See
+   \code{\link{genoud}} for further details.}
 }
 
 \value{ A list with components:

--- a/man/max_EQI.Rd
+++ b/man/max_EQI.Rd
@@ -9,7 +9,7 @@ Maximization, based on the package rgenoud of the Expected Quantile Improvement 
 
 \usage{
 max_EQI(model, new.noise.var=0, beta=0.9, q.min=NULL, type = "UK", lower, 
-upper, parinit=NULL, control=NULL)
+upper, parinit=NULL, control=NULL, cluster=FALSE)
 }
 
 \arguments{
@@ -34,7 +34,12 @@ upper, parinit=NULL, control=NULL)
 One can control  \code{"pop.size"}  (default : [N=3*2^dim for dim<6 and N=32*dim otherwise]),  \code{"max.generations"} (12),  
 \code{"wait.generations"} (2) and  \code{"BFGSburnin"} (2) of function  \code{"genoud"} (see \code{\link[rgenoud]{genoud}}). 
 Numbers into brackets are the default values } 
-
+   \item{cluster}{to invoke \code{\link{km}} and \code{\link{genoud}} in parallel, 
+     an object of the 'cluster' class returned
+     by one of the \code{\link{makeCluster}} commands in the
+     \sQuote{parallel} 
+     package, or a vector of machine names.  See
+     \code{\link{genoud}} for further details.}
 }
 
 \value{A list with components:

--- a/man/max_qEI.Rd
+++ b/man/max_qEI.Rd
@@ -15,7 +15,7 @@ Maximization of the \code{\link{qEI}} criterion. Two options are available : Con
 
 \usage{
 max_qEI(model, npoints, lower, upper, crit = "exact", 
-minimization = TRUE, optimcontrol = NULL)
+minimization = TRUE, optimcontrol = NULL, cluster=FALSE)
 }
 
 \arguments{
@@ -33,6 +33,12 @@ minimization = TRUE, optimcontrol = NULL)
   \item{minimization}{ logical specifying if the qEI to be maximized is used in minimiziation or in maximization, }
   
   \item{optimcontrol}{  an optional list of control parameters for optimization. See details.}
+  \item{cluster}{to invoke \code{\link{km}} and \code{\link{genoud}} in parallel, 
+     an object of the 'cluster' class returned
+     by one of the \code{\link{makeCluster}} commands in the
+     \sQuote{parallel} 
+     package, or a vector of machine names.  See
+     \code{\link{genoud}} for further details.}
 
 }
 

--- a/man/min_quantile.Rd
+++ b/man/min_quantile.Rd
@@ -8,7 +8,8 @@
 Minimization, based on the package rgenoud of the kriging quantile.}
 
 \usage{
-min_quantile(model, beta=0.1, type = "UK", lower, upper, parinit=NULL, control=NULL)
+min_quantile(model, beta=0.1, type = "UK", lower, upper, parinit=NULL,
+control=NULL, cluster=FALSE)
 }
 
 \arguments{
@@ -28,6 +29,12 @@ min_quantile(model, beta=0.1, type = "UK", lower, upper, parinit=NULL, control=N
 One can control  \code{"pop.size"}  (default : [N=3*2^dim for dim<6 and N=32*dim otherwise]),  \code{"max.generations"} (12),  
 \code{"wait.generations"} (2) and  \code{"BFGSburnin"} (2) of function  \code{"genoud"} (see \code{\link[rgenoud]{genoud}}). 
 Numbers into brackets are the default values } 
+   \item{cluster}{to invoke \code{\link{km}} and \code{\link{genoud}} in parallel, 
+     an object of the 'cluster' class returned
+     by one of the \code{\link{makeCluster}} commands in the
+     \sQuote{parallel} 
+     package, or a vector of machine names.  See
+     \code{\link{genoud}} for further details.}
 
 }
 

--- a/man/noisy.optimizer.Rd
+++ b/man/noisy.optimizer.Rd
@@ -14,7 +14,8 @@ The criterion optimization is based on the package rgenoud.
 \usage{
 noisy.optimizer(optim.crit, optim.param=NULL, model, n.ite, noise.var=NULL, 
 funnoise, lower, upper, parinit=NULL, control=NULL, CovReEstimate=TRUE, 
-NoiseReEstimate=FALSE, nugget.LB=1e-5, estim.model=NULL, type="UK")
+NoiseReEstimate=FALSE, nugget.LB=1e-5, estim.model=NULL, type="UK",
+  cluster=FALSE)
 }
 
 \arguments{
@@ -63,6 +64,13 @@ Numbers into brackets are the default values }
 Required if noise variance is reestimated and the initial "model" has heterogenenous noise variances.}
 
    \item{type}{"SK" or "UK" for Kriging with known or estimated trend}
+   \item{cluster}{to invoke \code{\link{genoud}} in parallel, 
+   an object of the 'cluster' class returned
+   by one of the \code{\link{makeCluster}} commands in the
+   \sQuote{parallel} 
+   package or a vector of machine names.  See
+   \code{\link{genoud}} for further details.  Currently
+   only supported for \dQuote{AKG} criterion.}
 }
 
 \value{A list with components:

--- a/man/noisy.optimizer.Rd
+++ b/man/noisy.optimizer.Rd
@@ -69,8 +69,7 @@ Required if noise variance is reestimated and the initial "model" has heterogene
    by one of the \code{\link{makeCluster}} commands in the
    \sQuote{parallel} 
    package, or a vector of machine names.  See
-   \code{\link{genoud}} for further details.  Currently
-   only supported for \dQuote{AKG} criterion.}
+   \code{\link{genoud}} for further details.}
 }
 
 \value{A list with components:

--- a/man/noisy.optimizer.Rd
+++ b/man/noisy.optimizer.Rd
@@ -64,11 +64,11 @@ Numbers into brackets are the default values }
 Required if noise variance is reestimated and the initial "model" has heterogenenous noise variances.}
 
    \item{type}{"SK" or "UK" for Kriging with known or estimated trend}
-   \item{cluster}{to invoke \code{\link{genoud}} in parallel, 
+   \item{cluster}{to invoke \code{\link{km}} and \code{\link{genoud}} in parallel, 
    an object of the 'cluster' class returned
    by one of the \code{\link{makeCluster}} commands in the
    \sQuote{parallel} 
-   package or a vector of machine names.  See
+   package, or a vector of machine names.  See
    \code{\link{genoud}} for further details.  Currently
    only supported for \dQuote{AKG} criterion.}
 }

--- a/man/update_km_noisyEGO.Rd
+++ b/man/update_km_noisyEGO.Rd
@@ -8,7 +8,8 @@
 \usage{
 update_km_noisyEGO(model, x.new, y.new, noise.var=0, type="UK", 
 add.obs=TRUE, index.in.DOE=NULL, CovReEstimate=TRUE, 
-NoiseReEstimate=FALSE, estim.model=NULL, nugget.LB=1e-5)
+NoiseReEstimate=FALSE, estim.model=NULL, nugget.LB=1e-5,
+cluster=NULL)
 }
 \arguments{
   \item{model}{ a Kriging model of "km" class }
@@ -22,6 +23,14 @@ NoiseReEstimate=FALSE, estim.model=NULL, nugget.LB=1e-5)
   \item{NoiseReEstimate}{ optional boolean specfiying if the noise variance should be re-estimated (default value = TRUE) }
   \item{estim.model}{ optional input of "km" class. Required if NoiseReEstimate=TRUE, in order to deal with repetitions.}
   \item{nugget.LB}{optional scalar: is used to define a lower bound on the noise variance.}
+  \item{cluster}{to invoke \code{\link{km}} and \code{\link{genoud}} in parallel, 
+    an object of the 'cluster' class returned
+    by one of the \code{\link{makeCluster}} commands in the
+    \sQuote{parallel} 
+    package, or a vector of machine names.  See
+    \code{\link{genoud}} for further details.  Currently
+    only supported for \dQuote{AKG} criterion.
+  }
 }
 
 \value{

--- a/man/update_km_noisyEGO.Rd
+++ b/man/update_km_noisyEGO.Rd
@@ -9,7 +9,7 @@
 update_km_noisyEGO(model, x.new, y.new, noise.var=0, type="UK", 
 add.obs=TRUE, index.in.DOE=NULL, CovReEstimate=TRUE, 
 NoiseReEstimate=FALSE, estim.model=NULL, nugget.LB=1e-5,
-cluster=NULL)
+cluster=FALSE)
 }
 \arguments{
   \item{model}{ a Kriging model of "km" class }
@@ -27,9 +27,7 @@ cluster=NULL)
     an object of the 'cluster' class returned
     by one of the \code{\link{makeCluster}} commands in the
     \sQuote{parallel} 
-    package, or a vector of machine names.  See
-    \code{\link{genoud}} for further details.  Currently
-    only supported for \dQuote{AKG} criterion.
+    package.
   }
 }
 


### PR DESCRIPTION
Dear DiceOptim authors,
I noticed that DiceOptim does not allow genoud optimizer to use multiple processor cores.  Is there any good reason for that?  Here are a few changes that make it available (through 'cluster' argument in genoud).  I only made it for AKG criterion, I know too little about the method to do extensive testing.  It speeds up calculations by about 3x on 8 cores.

And thank you for the package :-)
