### PR TITLE
Fixing qEI.grad.R to work with 1d data

### DIFF
--- a/R/EI.grad.R
+++ b/R/EI.grad.R
@@ -158,7 +158,7 @@ EI.grad <- function(x, model, plugin=NULL, type="UK", minimization = TRUE, envir
   } else 
   { # Compute derivatives of the covariance and trend functions
     dc <- covVector.dx(x=newdata.num, X=X, object=covStruct, c=c)  
-    f.deltax <- matrix(trend.deltax(x=newdata.num, model=model))
+    f.deltax <- matrix(trend.deltax(x=newdata.num, model=model), ncol=d)
   
     # Compute gradients of the kriging mean and variance
     W <- backsolve(t(T), dc, upper.tri=FALSE)

--- a/R/EI.grad.R
+++ b/R/EI.grad.R
@@ -158,7 +158,7 @@ EI.grad <- function(x, model, plugin=NULL, type="UK", minimization = TRUE, envir
   } else 
   { # Compute derivatives of the covariance and trend functions
     dc <- covVector.dx(x=newdata.num, X=X, object=covStruct, c=c)  
-    f.deltax <- trend.deltax(x=newdata.num, model=model)
+    f.deltax <- matrix(trend.deltax(x=newdata.num, model=model))
   
     # Compute gradients of the kriging mean and variance
     W <- backsolve(t(T), dc, upper.tri=FALSE)

--- a/R/qEI.grad.R
+++ b/R/qEI.grad.R
@@ -119,7 +119,7 @@ krigingDeriv <- function(x, model, type="UK", envir=NULL){
     f.deltax <- trend.deltax(x=newdata.num[k,], model=model)
     # Compute gradients of the kriging mean at point k
     W <- backsolve(t(T), dc, upper.tri=FALSE)
-    kriging.mean.jacob[k,,k] <- t(z)%*%W + model@trend.coef%*%matrix(f.deltax)
+    kriging.mean.jacob[k,,k] <- t(z)%*%W + model@trend.coef%*%matrix(f.deltax, ncol=d)
     # Compute gradients of the kriging covariance between point k and point l
     for (l in 1:q) {
         # Compute gradients of the kernel between point k and point l

--- a/R/qEI.grad.R
+++ b/R/qEI.grad.R
@@ -119,7 +119,7 @@ krigingDeriv <- function(x, model, type="UK", envir=NULL){
     f.deltax <- trend.deltax(x=newdata.num[k,], model=model)
     # Compute gradients of the kriging mean at point k
     W <- backsolve(t(T), dc, upper.tri=FALSE)
-    kriging.mean.jacob[k,,k] <- t(z)%*%W + model@trend.coef%*%f.deltax
+    kriging.mean.jacob[k,,k] <- t(z)%*%W + model@trend.coef%*%matrix(f.deltax)
     # Compute gradients of the kriging covariance between point k and point l
     for (l in 1:q) {
         # Compute gradients of the kernel between point k and point l

--- a/R/qEI.grad.R
+++ b/R/qEI.grad.R
@@ -123,7 +123,7 @@ krigingDeriv <- function(x, model, type="UK", envir=NULL){
     # Compute gradients of the kriging covariance between point k and point l
     for (l in 1:q) {
         # Compute gradients of the kernel between point k and point l
-        ker.grad <- covVector.dx(x=newdata.num[k,], X=newdata[l,],
+        ker.grad <- covVector.dx(x=newdata.num[k,], X=matrix(newdata[l,], ncol=d),
                                  object=covStruct, c=covM[k,l])
         kriging.cov.jacob[k,,k,l] <- ker.grad - t(v[,l])%*%W
         if (type=="UK") {

--- a/R/qEI.grad.R
+++ b/R/qEI.grad.R
@@ -296,7 +296,7 @@ qEI.grad <- function(x, model, plugin=NULL, type="UK", minimization = TRUE, fast
     if (!minimization) {
       stop("qEI.grad doesn't work in \'minimization = FALSE\' when dim = 1 (in progress).")
     }
-    return(EI.grad(x,model,plugin,type,envir))
+    return(EI.grad(x,model,plugin,type,minimization,envir))
   }
   
   if(!is.null(envir)) {


### PR DESCRIPTION
When `qEI.grad.R` is called on 1d data an error occurs.

Minimal example (R v.3.3, DiceOptim v.2):
```
library('DiceOptim')
x_all <- replicate(1, rnorm(5))
y_all <- matrix(0, nrow=5, ncol=1)
m <- km(design=data.frame(x_all), response=data.frame(y_all), coef.cov=c(.1), coef.var=c(1))
x <- replicate(1, rnorm(6))
qEI.grad(x, m)
```

This PR addresses this issue.